### PR TITLE
Emit events to the same server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -2,7 +2,7 @@ var EventEmitter = Npm.require('events').EventEmitter;
 var util = Npm.require('util');
 var Fibers = Npm.require('fibers');
 
-Meteor.Stream = function Stream(name) {
+Meteor.Stream = function Stream(name, localEmit) {
   EV.call(this);
 
   var self = this;
@@ -21,6 +21,12 @@ Meteor.Stream = function Stream(name) {
 
   self._emit = self.emit;
   self.emit = function emit() {
+    // emit the event to the server so others - i.e. other packages - can react
+    // to the event (useful when creating your own packages and no db needs to
+    // be involved)
+    if ( localEmit ) {
+      self._emit(arguments[0], arguments[1]); 
+    }
     self.emitToSubscriptions(arguments, null, null);
   };
 


### PR DESCRIPTION
Let others in the same server be notified when an event is emitted from the server. I.E. one package emits an event in the sever. If a related package needs to be aware on the server side of the event it was impossible unless listens for item and checks the content.
